### PR TITLE
Add cover image upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+target
+src/main/webapp/WEB-INF/classes/
+.classpath
+.project
+/bin
+.settings

--- a/src/main/java/fi/seco/saha3/web/control/ImageUploadController.java
+++ b/src/main/java/fi/seco/saha3/web/control/ImageUploadController.java
@@ -1,0 +1,71 @@
+package fi.seco.saha3.web.control;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import com.google.common.io.Files;
+import java.io.File;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Set;
+
+import fi.seco.saha3.infrastructure.SahaProjectRegistry;
+
+@Controller
+public class ImageUploadController {
+	@Autowired
+	private SahaProjectRegistry registry;
+
+	@Value("#{WWWDomain}")
+	private String www_domain;
+
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/service/pics_upload"
+	)
+	public String upload(
+		RedirectAttributes redirAttr,
+		@RequestParam("image") MultipartFile file,
+		@RequestParam("target") String target,
+		@RequestParam("model") String model,
+		@RequestParam("property") String property) throws Exception {
+
+		if (file.isEmpty()) {
+			return "Invalid file";
+		}
+
+		// Compute hash of image content and use it as filename.
+		// Copy file extension to new name.
+		byte[] image_byte_hash = MessageDigest
+			.getInstance("SHA-256")
+			.digest(file.getBytes());
+		String image_hash = Base64
+			.getUrlEncoder()
+			.withoutPadding()
+			.encodeToString(image_byte_hash);
+		String name = image_hash + '.' + Files.getFileExtension(file.getOriginalFilename());
+
+		File picFile = new File(registry.getProjectBaseDirectory() + model + "/pics/" + name);
+		file.transferTo(picFile);
+
+		Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-r--r--");
+		java.nio.file.Files.setPosixFilePermissions(picFile.toPath(), permissions);
+
+		String image_url = this.www_domain + "images/" + model + '/' + name;
+
+		redirAttr.addAttribute("uri", target);
+		redirAttr.addAttribute("image_url", image_url);
+		redirAttr.addAttribute("target", target);
+		redirAttr.addAttribute("property", property);
+		redirAttr.addAttribute("model", model);
+
+		return "redirect:/project/editor.shtml";
+	}
+}

--- a/src/main/resources/localConfiguration.xml
+++ b/src/main/resources/localConfiguration.xml
@@ -21,4 +21,8 @@
 		<constructor-arg value="/srv/saha/backups/"/>
 	</bean>
 
+	<bean id="WWWDomain" class="java.lang.String">
+		<constructor-arg value="https://saha.kirjastot.fi/"/>
+	</bean>
+
 </beans>

--- a/src/main/resources/saha3-beans.xml
+++ b/src/main/resources/saha3-beans.xml
@@ -14,15 +14,28 @@
 	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd
 	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
 	http://www.directwebremoting.org/schema/spring-dwr http://www.directwebremoting.org/schema/spring-dwr-3.0.xsd
-	http://www.springframework.org/schema/web-services http://www.springframework.org/schema/web-services/web-services-2.0.xsd"
-  default-lazy-init="true" 
-  default-autowire="no" >
+	http://www.springframework.org/schema/web-services http://www.springframework.org/schema/web-services/web-services-2.0.xsd
+	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+  default-lazy-init="true"
+  default-autowire="no"
+>
 
 	<description>SAHA3 web tier specific beans</description>
 	
 	<mvc:resources mapping="/app/**" location="/app/" />
 	<mvc:resources mapping="/app/scripts/dwr/**" location="/scripts/" />
-	
+
+	<!-- Automatically load all controllers with annotations -->
+	<context:component-scan base-package="fi.seco.saha3.web.control" />
+	<mvc:annotation-driven />
+
+	<!-- Enable multipart form support -->
+	<bean
+		id="multipartResolver"
+		class="org.springframework.web.multipart.commons.CommonsMultipartResolver"
+	>
+	</bean>
+
 	<bean class="org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter"/>
 	<bean class="org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter"/>
 
@@ -178,7 +191,7 @@
 	
 	<bean id="Saha3ImageController" class="fi.seco.saha3.web.control.ImageController"
 	p:sahaProjectRegistry-ref="SahaProjectRegistry" />
-		
+
 	<!--   <bean id="ModelLister" class="fi.seco.saha3.model.RemoteSPARQLModelLister"
 	p:sparqlService="http://80.69.172.23:3030/kirjasampo/sparql" /> -->
 	

--- a/src/main/resources/webtier-beans.xml
+++ b/src/main/resources/webtier-beans.xml
@@ -53,9 +53,6 @@
 			value="true" />
 	</dwr:controller>
 
-	<bean id="multipartResolver"
-		class="org.springframework.web.multipart.commons.CommonsMultipartResolver" />
-
 	<!-- freemarker config -->
 	<bean id="fmConfigurer"
 		class="org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer">

--- a/src/main/webapp/WEB-INF/app/saha3/support/editor_common.ftl
+++ b/src/main/webapp/WEB-INF/app/saha3/support/editor_common.ftl
@@ -267,11 +267,11 @@
 	[#assign isPicture = property.config.pictureProperty /]
 	[#if !inline && !isPicture]<div style="color:#888;">add new literal</div>[/#if]
 	[#if !inline && isPicture]
-		<form action="http://media.onki.fi/upload" enctype="multipart/form-data" method="post">
+		<form action="/saha/service/pics_upload" enctype="multipart/form-data" method="post">
 			<div style="color:#888;margin-bottom:5px;">upload file</div>
 			<input name="image" type="file">
 			<input name="target" type="hidden" value="${resourceUri}"/>
-			<input name="context" type="hidden" value="saha/${model}"/>
+			<input name="model" type="hidden" value="${model}"/>
 			<input name="property" type="hidden" value="${property.uri}"/>
 			<input type="submit" value="Upload"/>
 		</form>
@@ -423,7 +423,7 @@
 			[#assign label=propertyValueLabel]
 			[#if isPictureProperty || label?ends_with(".jpg") || label?ends_with(".jpeg") || label?ends_with(".png") || label?ends_with(".gif")]
 				<div style="margin:5px;">
-				[#if label?starts_with("http://") && !label?starts_with("http://demo.seco.tkk.fi/")]
+				[#if (label?starts_with("http://") || label?starts_with("https://")) && !label?starts_with("http://demo.seco.tkk.fi/")]
 					<a href="${label}" style="color:darkblue">
 					<img src="${label}" style="max-width:60px;max-height:60px;margin-right:5px;
 						border:thin solid black;"/></a>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -43,17 +43,6 @@
 		<url-pattern>/*</url-pattern>
 	</servlet-mapping>
 
-
-	<servlet-mapping>
-		<servlet-name>spring-mvc</servlet-name>
-		<url-pattern>/service/*</url-pattern>
-	</servlet-mapping>
-
-	<servlet-mapping>
-		<servlet-name>spring-mvc</servlet-name>
-		<url-pattern>/project/*</url-pattern>
-	</servlet-mapping>
-
 	<servlet-mapping>
 		<servlet-name>spring-mvc</servlet-name>
 		<url-pattern>/dwr/*</url-pattern>


### PR DESCRIPTION
* A new parameter WWWDomain must be configured, as images need an
  absolute url.
* Images are stored under projects '/pics' directory, with sha256 hash
  of file content as its name to prevent file name collisions.
* Files get read permission for all users, so that they can be served
  with http server (ex. Nginx). They should be also available through
  ImageController.
* Remove some apparently unnecesary servlet-mappings as they interfere
  with mvc:annotation-driven configuration.